### PR TITLE
Add dependencies to run scraping server

### DIFF
--- a/protobufs/requirements.txt
+++ b/protobufs/requirements.txt
@@ -1,1 +1,4 @@
+aiohttp~=3.7.4
+aiohttp_socks~=0.6.0
+beautifulsoup4~=4.9.1
 grpcio-tools ~= 1.30


### PR DESCRIPTION
Closes #6 

Add all of the dependencies required to run the server. These libraries provide an asynchronous HTTP client and an HTML parser. 